### PR TITLE
Add options to skip RMBG-2.0 background removal, or replace it with another model

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -71,9 +71,9 @@ def load_moge_model(device="cuda", model_name=MOGE_MODEL_NAME):
     return moge_model
 
 
-def init_pipeline(model_path=MODEL_PATH, device="cuda", low_vram=False):
+def init_pipeline(model_path=MODEL_PATH, device="cuda", low_vram=False, rembg_model_name=...):
     print(f"[Pipeline] Loading from {model_path}...")
-    pipeline = Pixal3DImageTo3DPipeline.from_pretrained(model_path)
+    pipeline = Pixal3DImageTo3DPipeline.from_pretrained(model_path, rembg_model_name=rembg_model_name)
 
     print("[ImageCond] Building DinoV3ProjFeatureExtractor models...")
     pipeline.image_cond_model_ss = build_image_cond_model(IMAGE_COND_CONFIGS["ss"])
@@ -182,9 +182,10 @@ def run_inference(
     manual_fov: float = -1.0,
     low_vram: bool = False,
     resolution: int = -1,
+    rembg_model_name = ...,
 ):
     # Load models
-    pipeline = init_pipeline(model_path, low_vram=low_vram)
+    pipeline = init_pipeline(model_path, low_vram=low_vram, rembg_model_name=rembg_model_name)
 
     # Preprocess image first — rembg loads to GPU for this call, then offloads.
     # MoGe is loaded afterwards so both never occupy VRAM at the same time.
@@ -298,8 +299,24 @@ if __name__ == "__main__":
                              "Reduces peak VRAM from ~18GB to ~10-12GB at the cost of slower inference.")
     parser.add_argument("--resolution", type=int, default=-1,
                         help="Pipeline resolution (1024 or 1536). Default: 1024 if --low_vram, else 1536.")
+    parser.add_argument("--no_rembg", action="store_true",
+                        help="Skip background removal entirely. "
+                             "Works best with images that already have an alpha channel (e.g. pre-masked PNGs). "
+                             "For plain RGB images the full frame is treated as foreground.")
+    parser.add_argument("--rembg_model", type=str, default=None,
+                        help="Override the background-removal model loaded from the pipeline config. "
+                             "E.g. 'ZhengPeng7/BiRefNet' is an MIT-licensed drop-in replacement for "
+                             "the default 'briaai/RMBG-2.0' (which requires gated HuggingFace access). "
+                             "Ignored when --no_rembg is set.")
 
     args = parser.parse_args()
+
+    if args.no_rembg:
+        rembg_model_name = None
+    elif args.rembg_model:
+        rembg_model_name = args.rembg_model
+    else:
+        rembg_model_name = ...
 
     run_inference(
         image_path=args.image,
@@ -309,4 +326,5 @@ if __name__ == "__main__":
         model_path=args.model_path,
         low_vram=args.low_vram,
         resolution=args.resolution,
+        rembg_model_name=rembg_model_name,
     )

--- a/pixal3d/pipelines/pixal3d_image_to_3d.py
+++ b/pixal3d/pipelines/pixal3d_image_to_3d.py
@@ -92,12 +92,19 @@ class Pixal3DImageTo3DPipeline(Pipeline):
         self._device = 'cpu'
 
     @classmethod
-    def from_pretrained(cls, path: str, config_file: str = "pipeline.json") -> "Pixal3DImageTo3DPipeline":
+    def from_pretrained(cls, path: str, config_file: str = "pipeline.json", rembg_model_name = ...) -> "Pixal3DImageTo3DPipeline":
         """
         Load a pretrained model.
 
         Args:
             path (str): The path to the model. Can be either local path or a Hugging Face repository.
+            rembg_model_name: Override the HuggingFace model name used for background removal.
+                Use a string such as "ZhengPeng7/BiRefNet" (MIT-licensed) to replace the default
+                gated model from the pipeline config.
+                Pass None to skip loading any background removal model; images with an existing
+                alpha channel will still be handled correctly, and images without one will have
+                their full content treated as foreground.
+                Defaults to ... (Ellipsis), which means "use whatever the pipeline config says".
         """
         pipeline = super().from_pretrained(path, config_file)
         args = pipeline._pretrained_args
@@ -120,7 +127,13 @@ class Pixal3DImageTo3DPipeline(Pipeline):
         pipeline.image_cond_model_shape_1024 = None
         pipeline.image_cond_model_tex_1024 = None
 
-        pipeline.rembg_model = getattr(rembg, args['rembg_model']['name'])(**args['rembg_model']['args'])
+        if rembg_model_name is None:
+            pipeline.rembg_model = None
+        else:
+            rembg_args = args['rembg_model']['args'].copy()
+            if rembg_model_name is not ...:
+                rembg_args['model_name'] = rembg_model_name
+            pipeline.rembg_model = getattr(rembg, args['rembg_model']['name'])(**rembg_args)
         
         pipeline.low_vram = args.get('low_vram', True)
         pipeline.default_pipeline_type = args.get('default_pipeline_type', '1024_cascade')
@@ -161,6 +174,8 @@ class Pixal3DImageTo3DPipeline(Pipeline):
             input = input.resize((int(input.width * scale), int(input.height * scale)), Image.Resampling.LANCZOS)
         if has_alpha:
             output = input
+        elif self.rembg_model is None:
+            output = input.convert('RGBA')
         else:
             input = input.convert('RGB')
             if self.low_vram:


### PR DESCRIPTION
RMBG-2.0 is not available for download from Huggingface without obtaining an explicit permission from them.
This PR allows replacing it with other compatible models, such as `ZhengPeng7/BiRefNet`, or skipping background removal completely (e.g. if image is already masked).